### PR TITLE
Added ability to pass through up to 4 devices

### DIFF
--- a/drivers_source/cam_drv_src/veye,vbyone.txt
+++ b/drivers_source/cam_drv_src/veye,vbyone.txt
@@ -18,7 +18,9 @@ Integer values:
 - csi-lane-speed        CSI lane speed in Mbps (900, 1118 or 1500)
                                                         default vaule: 1500
 - coax-num              Number of Coax cable
-- cam-i2c-pt-setting    Pass through setting i2c
+- device-i2c-pt-setting Pass through setting i2c
+- num-devices           Number of devices
+- devices-i2c-addresses I2C addresses of devices (0x3b)
 
 String values:
 - pdb-gpio              Power-down gpio(no use or polling)        
@@ -40,7 +42,6 @@ Integer values:
 - i2c-address           I2C address of serializer(0x36)  
 - csi-lane-count        Number of CSI lanes   default value: 2
 - csi-lane-speed        CSI lane speed in Mbps (900, 1118 or 1500)
-- camera-i2c-address   I2C address of camera(0x3b)
 
 /*------------------------------------------------------------------------------
 * ------------------------------------------------------------------------------
@@ -62,17 +63,19 @@ veye_vbyone: vbyone@65 {
     csi-lane-count = <2>;
     csi-lane-speed = <1500>;
     coax-num = <1>;
-    cam-i2c-pt-setting = <0x13>;
+    device-i2c-pt-setting = <0x13>;
 
     pdb-gpio-mode = <0>;
     trgin-gpio-mode = <1>;
     out1-gpio-mode = <1>;
     out2-gpio-mode = <1>;
     
+    num-devices = <1>;
+    devices-i2c-addresses=<0x3b>;
+    
     serializer {
         i2c-address=<0x34>;
         csi-lane-count = <2>;
         csi-lane-speed = <1500>;
-        camera-i2c-address=<0x3b>;
     };
 };

--- a/drivers_source/cam_drv_src/veye_vbyone.h
+++ b/drivers_source/cam_drv_src/veye_vbyone.h
@@ -28,6 +28,8 @@
  * Deserializer registers
  *----------------------------------------------------------------------------*/
 #define R_2WIREPT_WA_DATA_BYTE 0x0032
+
+#define MAX_DEVICES			   4
 #define R_2WIREPT1_PASS_ADR000 0x0040
 #define R_2WIREPT1_PASS_ADR001 0x0041
 
@@ -76,8 +78,9 @@ struct thcv242a_priv {
 
 	int csi_lane_count;
 	int coax_num;
-	int cam_i2c_pt_setting;
-    int cam_i2c_address;
+	int device_i2c_pt_setting;
+	int num_devices;
+	u32 *devices_i2c_addresses;
     
     int trgin_gpio_mode; // 0: no use ;1 : polling
 	int out1_gpio_mode; // 0: no use ;1 : polling


### PR DESCRIPTION
Some cameras are more than one i2c device, like in my case where the camera consists of two i2c devices: the sensor and the fpga, which is essential for the sensor to work properly. So I added the ability to pass through more than one device.